### PR TITLE
Correct return type of cume_dist() in docs

### DIFF
--- a/presto-docs/src/main/sphinx/functions/window.rst
+++ b/presto-docs/src/main/sphinx/functions/window.rst
@@ -121,7 +121,7 @@ by day for each clerk::
 Ranking Functions
 -----------------
 
-.. function:: cume_dist() -> bigint
+.. function:: cume_dist() -> double
 
     Returns the cumulative distribution of a value in a group of values.
     The result is the number of rows preceding or peer with the row in the


### PR DESCRIPTION
## Description
The `cume_dist()` window function returns a double between 0 and 1. The docs incorrectly stated that it returns a bigint.

## Motivation and Context
See above

## Impact
Docs only

## Test Plan
N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```
